### PR TITLE
Make branch name unique

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -320,7 +320,7 @@ async function createPullRequest(cityname, username, tmpFolder) {
     await git.config('user.email', BOT_EMAIL);
     await git.config('user.name', BOT_NAME);
 
-    const branchName = username;
+    const branchName = `${username}-${Date.now()}`;
 
     await git.branch(branchName);
     await git.checkout(branchName);


### PR DESCRIPTION
Issue:

Can't create a PR with same branch name twice.

Fix:
Make branch name unique