### PR TITLE
Add missing await keyword

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -405,7 +405,7 @@ async function submitProfile(
 ) {
   try {
     const message = `Username: ${_username}\n\nCity: ${_cityname}\n\nE-Mail: ${_email}\n\n${_filecontentDE}\n\n${_filecontentEN}\n\n`;
-    sendEmail(message)
+    await sendEmail(message)
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
When using try/catch you need to use the `await` keyword otherwise the promise will not be handled correctly.